### PR TITLE
Upgraded selenium-java to 3.4.0 (#53)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,21 @@ java -jar <path to jar> -<argument name> [<argument value> ...]
 | *screenshotType*  | optional | Defines the way screenshots must be taken - fullscreen vs. viewport. | `VIEW_PORT` | `FULLSCREEN` |
 | *screenshotFormat*  | optional | Defines the screenshot format. | `png` | `gif` |
 | *takeScreenshots*  | optional | Defines when to take screenshots: NEVER, ON_FAILURE, ON_EVERY_STEP | `ON_FAILURE` | `./` |
-| *browser*  | optional | A browser can be selected by passing this option when running JWebRobot. Please consider that some browsers require additional configuration parameters. WAML scenarios are executed with Mozilla Firefox per default. Firefox must be installed on the same machine. E.g.: Chrome does not provide embedded webdriver so that it has to be [downloaded manually](webdriver-chrome). The path to the downloaded executable has to be forwarded via the system property `webdriver.chrome.driver`. Of course, Chrome must be present on the same machine. | `firefox` | `chrome` |
+| *browser*  | optional | A browser can be selected by passing this option when running JWebRobot. Please consider that some browsers require additional configuration parameters. WAML scenarios are executed with Mozilla Firefox per default. Firefox must be installed on the same machine. E.g.: Chrome does not provide embedded webdriver so that it has to be [downloaded manually](webdriver-chrome). The path to the downloaded executable has to be forwarded via the system property `webdriver.chrome.driver`. Of course, Chrome must be present on the same machine. | `firefox` | `chrome`, `chrome-headless`, `opera`  |
 | *reportPath*  | optional  | Path to which the report is written to. | `./report.yaml` | `./myreport.yaml` |
 | *maximizeWindow* | optional | Toggles window maximization before scenario execution. | `false` | `true` |
 | *mode* | optional | Selects the execution mode. Currently legacy non-interactive and interactive mode with the possibility to pause/step-wise execution are supported. | `non-interactive` | `interactive` |
+
+## Supported Browses
+
+Currently, the following browses-webdriver combinations are supported:
+
+| Browser | Version | WebDriver |
+|---------|---------|-----------|
+| Chrome  | 59.0.3071.115 | [2.30](http://chromedriver.storage.googleapis.com/index.html?path=2.30/) |
+| Firefox | 54.0.1  | [v0.17.0](https://github.com/mozilla/geckodriver/releases) |
+| Opera   | 46.0.2597.39 | [2.29](https://github.com/operasoftware/operachromiumdriver/releases) |
+
 
 ## Expressions
 Expression are evaluated by the awesome templating engine [freemarker]. The expression syntax and result may be tested using online [template-tester].

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <selenium-java.version>2.53.1</selenium-java.version>
+        <selenium-java.version>3.4.0</selenium-java.version>
     </properties>
 
     <licenses>

--- a/src/main/java/website/automate/jwebrobot/executor/ExecutionResults.java
+++ b/src/main/java/website/automate/jwebrobot/executor/ExecutionResults.java
@@ -1,4 +1,0 @@
-package website.automate.jwebrobot.executor;
-
-public class ExecutionResults {
-}

--- a/src/main/java/website/automate/jwebrobot/report/Reporter.java
+++ b/src/main/java/website/automate/jwebrobot/report/Reporter.java
@@ -78,7 +78,7 @@ public class Reporter implements ExecutionEventListener {
         actionReportMap.put(action, actionReport);
     }
 
-    private void processLogEntries(ScenarioExecutionContext context, ActionReport actionReport) {
+    void processLogEntries(ScenarioExecutionContext context, ActionReport actionReport) {
         try {
             List<org.openqa.selenium.logging.LogEntry> logEntries = context.getDriver().manage().logs().get(LogType.BROWSER).getAll();
             ExecutorOptions options = context.getGlobalContext().getOptions();

--- a/src/main/java/website/automate/jwebrobot/report/Reporter.java
+++ b/src/main/java/website/automate/jwebrobot/report/Reporter.java
@@ -83,6 +83,7 @@ public class Reporter implements ExecutionEventListener {
             List<org.openqa.selenium.logging.LogEntry> logEntries = context.getDriver().manage().logs().get(LogType.BROWSER).getAll();
             ExecutorOptions options = context.getGlobalContext().getOptions();
 
+            // TODO extract mapper
             List<LogEntry> convertedLogEntries = new ArrayList<>();
 
             for (org.openqa.selenium.logging.LogEntry logEntry : logEntries) {

--- a/src/test/java/website/automate/jwebrobot/report/ReporterTest.java
+++ b/src/test/java/website/automate/jwebrobot/report/ReporterTest.java
@@ -1,20 +1,30 @@
 package website.automate.jwebrobot.report;
 
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.openqa.selenium.UnsupportedCommandException;
 import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.logging.LogEntries;
+import org.openqa.selenium.logging.LogEntry;
 import org.openqa.selenium.logging.LogType;
 import org.openqa.selenium.logging.Logs;
 import website.automate.jwebrobot.context.ScenarioExecutionContext;
 import website.automate.waml.report.io.WamlReportWriter;
 import website.automate.waml.report.io.model.ActionReport;
 
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import java.util.List;
+import java.util.logging.Level;
+
+import static java.util.Arrays.asList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ReporterTest {
@@ -34,15 +44,54 @@ public class ReporterTest {
     @Mock
     private WebDriver webDriver;
 
+    @Mock
+    private WebDriver.Options options;
+
+    @Mock
+    private Logs logs;
+
+    @Mock
+    private website.automate.jwebrobot.context.GlobalExecutionContext globalContext;
+
+    @Mock
+    private website.automate.jwebrobot.executor.ExecutorOptions executorOptions;
+
+    @Captor
+    private ArgumentCaptor<List<website.automate.waml.report.io.model.LogEntry>> logEntryListCaptor;
+
+    @Before
+    public void setUpContext() {
+        when(context.getDriver()).thenReturn(webDriver);
+        when(webDriver.manage()).thenReturn(options);
+        when(options.logs()).thenReturn(logs);
+
+        when(context.getGlobalContext()).thenReturn(globalContext);
+        when(globalContext.getOptions()).thenReturn(executorOptions);
+    }
+
     @Test
     public void shouldNotThrowErrorIfBrowserLogForwardingIsNotSupportedByTheDriver() {
-        when(context.getDriver()).thenReturn(webDriver);
-        WebDriver.Options options = mock(WebDriver.Options.class);
-        when(webDriver.manage()).thenReturn(options);
-        Logs logs = mock(Logs.class);
-        when(options.logs()).thenReturn(logs);
         when(logs.get(LogType.BROWSER)).thenThrow(UnsupportedCommandException.class);
 
         reporter.processLogEntries(context, actionReport);
+    }
+
+    @Test
+    public void shouldConvertLogEntries() {
+        LogEntries logEntries = mock(LogEntries.class);
+        when(logs.get(LogType.BROWSER)).thenReturn(logEntries);
+        LogEntry logEntry = mock(LogEntry.class);
+        when(logEntries.getAll()).thenReturn(asList(logEntry));
+
+        when(logEntry.getLevel()).thenReturn(Level.FINEST);
+        when(executorOptions.getBrowserLogLevel()).thenReturn(website.automate.waml.report.io.model.LogEntry.LogLevel.DEBUG);
+
+        reporter.processLogEntries(context, actionReport);
+
+        verify(logEntries).getAll();
+
+        verify(actionReport).setLogEntries(logEntryListCaptor.capture());
+        List<website.automate.waml.report.io.model.LogEntry> logEntryList = logEntryListCaptor.getValue();
+        assertThat(logEntryList, hasSize(1));
     }
 }

--- a/src/test/java/website/automate/jwebrobot/report/ReporterTest.java
+++ b/src/test/java/website/automate/jwebrobot/report/ReporterTest.java
@@ -1,0 +1,48 @@
+package website.automate.jwebrobot.report;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.openqa.selenium.UnsupportedCommandException;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.logging.LogType;
+import org.openqa.selenium.logging.Logs;
+import website.automate.jwebrobot.context.ScenarioExecutionContext;
+import website.automate.waml.report.io.WamlReportWriter;
+import website.automate.waml.report.io.model.ActionReport;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ReporterTest {
+
+    @InjectMocks
+    private Reporter reporter;
+
+    @Mock
+    private WamlReportWriter writer;
+
+    @Mock
+    private ScenarioExecutionContext context;
+
+    @Mock
+    private ActionReport actionReport;
+
+    @Mock
+    private WebDriver webDriver;
+
+    @Test
+    public void shouldNotThrowErrorIfBrowserLogForwardingIsNotSupportedByTheDriver() {
+        when(context.getDriver()).thenReturn(webDriver);
+        WebDriver.Options options = mock(WebDriver.Options.class);
+        when(webDriver.manage()).thenReturn(options);
+        Logs logs = mock(Logs.class);
+        when(options.logs()).thenReturn(logs);
+        when(logs.get(LogType.BROWSER)).thenThrow(UnsupportedCommandException.class);
+
+        reporter.processLogEntries(context, actionReport);
+    }
+}


### PR DESCRIPTION
- Upgraded selenium-java to 3.4.0
- Catching error if browser log dumps are not supported (geckodriver)
- Added current browser-webdriver compatibility list
- Removed obsolete class